### PR TITLE
chore: update pre-commit workflow to run Prettier first and update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,16 +97,16 @@ docs: update API integration guide
 
    We use pre-commit hooks to automatically run quality checks before commits:
 
-   ```bash
-   # Quick validation (recommended during development)
-   pnpm quick-check   # Type checking + linting
+  ```bash
+  # Quick validation (recommended during development)
+  pnpm quick-check   # Type checking + linting
 
-   # Full pre-commit validation (runs automatically on git commit)
-   pnpm pre-commit    # All checks: type-check, lint, format, tests, a11y
+  # Full pre-commit validation (runs automatically on git commit)
+  pnpm pre-commit    # All checks: format, lint, type-check, tests, a11y (Prettier runs first)
 
-   # Complete validation including build
-   pnpm validate      # Pre-commit + build test
-   ```
+  # Complete validation including build
+  pnpm validate      # Pre-commit + build test
+  ```
 
    **Manual Testing Commands:**
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:coverage": "vitest run --coverage",
     "test:a11y": "vitest run --reporter=verbose --testNamePattern=\"accessibility|a11y\"",
     "check:no-secrets-logged": "node ./scripts/check-no-secrets-logged.js",
-    "pre-commit": "pnpm check:no-secrets-logged && pnpm type-check && pnpm lint && pnpm format:check && pnpm test && pnpm test:a11y",
+  "pre-commit": "pnpm format && pnpm check:no-secrets-logged && pnpm lint && pnpm type-check && pnpm test && pnpm test:a11y",
     "validate": "pnpm pre-commit && pnpm build",
     "quick-check": "pnpm type-check && pnpm lint"
   },


### PR DESCRIPTION
- pnpm format now runs before lint, type-check, and tests
- CONTRIBUTING.md updated to reflect new order
- All tests pass

This improves developer experience and prevents blocked commits due to code style issues.