### PR TITLE
chore: enforce ES module syntax and block require() imports

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,10 +76,12 @@ Before starting any development work, always review the key project documentatio
 - Define shared interfaces and types
 - Use descriptive naming conventions
 - Export types from index.ts files
+ - Export types from index.ts files (including all nested subfolders)
 - Avoid using 'any' type
 - Implement strict type checking
 - **Do not define shared types inline in components or actions.**
 - **Enforce usage via lint rules, pre-commit scripts, and code review checklists.**
+ - **All index.ts files in `src/types`, `src/schemas`, and `src/utils` (including nested subfolders) must use path aliases for all exports. Relative paths (e.g., `./...`) are not allowed.**
 
 ### Error Response Schema Strategy
 
@@ -133,6 +135,7 @@ Before starting any development work, always review the key project documentatio
 - Use regex or AST-based scripts to detect Zod schema and interface declarations outside their designated folders.
 - Make schema/type usage a checklist item in PR reviews.
 - Add code comments in components reminding contributors to use centralized schemas/types.
+ - **Enforcement tests must recursively scan all index.ts files in `src/types`, `src/schemas`, and `src/utils` (including nested subfolders) to ensure all exports use path aliases.**
 
 ### Type Safety
 
@@ -369,3 +372,4 @@ Examples:
 4. Use semantic commit messages
 5. Keep PRs focused and atomic
 6. Update the changelog if required
+7. **Reviewers must confirm that all index.ts files (including nested) use path aliases for exports.**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,10 +32,12 @@ Before starting any development work, always review the key project documentatio
 
 ### Scripts and Node.js Module Type
 
-- All scripts in `/scripts` must use ES module syntax (`import`/`export`).
-- The project sets `"type": "module"` in `package.json` to eliminate Node.js warnings and ensure modern compatibility.
-- Refactor any CommonJS scripts to ES modules if added in the future.
-- Validate scripts locally after any changes to ensure zero runtime warnings.
+ - All scripts in `/scripts` must use ES module syntax (`import`/`export`).
+ - The project sets `"type": "module"` in `package.json` to eliminate Node.js warnings and ensure modern compatibility.
+ - Refactor any CommonJS scripts to ES modules if added in the future.
+ - **`require()` imports are forbidden in all TypeScript code. This is enforced via ESLint (`@typescript-eslint/no-require-imports: error`).**
+ - Linting is run in pre-commit and CI workflows, blocking commits and PRs if violations are found.
+ - Validate scripts locally after any changes to ensure zero runtime warnings.
 
 ### Before Making Changes
 
@@ -76,12 +78,12 @@ Before starting any development work, always review the key project documentatio
 - Define shared interfaces and types
 - Use descriptive naming conventions
 - Export types from index.ts files
- - Export types from index.ts files (including all nested subfolders)
+- Export types from index.ts files (including all nested subfolders)
 - Avoid using 'any' type
 - Implement strict type checking
 - **Do not define shared types inline in components or actions.**
 - **Enforce usage via lint rules, pre-commit scripts, and code review checklists.**
- - **All index.ts files in `src/types`, `src/schemas`, and `src/utils` (including nested subfolders) must use path aliases for all exports. Relative paths (e.g., `./...`) are not allowed.**
+- **All index.ts files in `src/types`, `src/schemas`, and `src/utils` (including nested subfolders) must use path aliases for all exports. Relative paths (e.g., `./...`) are not allowed.**
 
 ### Error Response Schema Strategy
 
@@ -135,7 +137,7 @@ Before starting any development work, always review the key project documentatio
 - Use regex or AST-based scripts to detect Zod schema and interface declarations outside their designated folders.
 - Make schema/type usage a checklist item in PR reviews.
 - Add code comments in components reminding contributors to use centralized schemas/types.
- - **Enforcement tests must recursively scan all index.ts files in `src/types`, `src/schemas`, and `src/utils` (including nested subfolders) to ensure all exports use path aliases.**
+- **Enforcement tests must recursively scan all index.ts files in `src/types`, `src/schemas`, and `src/utils` (including nested subfolders) to ensure all exports use path aliases.**
 
 ### Type Safety
 
@@ -225,6 +227,7 @@ To ensure all code meets project standards and to avoid formatting or validation
 Always run `pnpm pre-commit` before `git add` or `git commit` to catch all formatting, lint, type, and test errors. Husky hooks automate this process and block commits with formatting errors.
 
 **Formatting enforcement:**
+
 - Formatting is enforced locally via Husky pre-commit hooks and in CI via the `pnpm format:check` job.
 - Contributors should run `pnpm pre-commit` and/or `pnpm format:check` before staging or committing changes.
 - PRs and merges will be blocked if formatting is incorrect.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -216,15 +216,18 @@ To ensure all code meets project standards and to avoid formatting or validation
 1. **Run `pnpm pre-commit` before staging or committing changes.**
    - This command runs formatting, linting, type-checking, and tests in the correct order.
    - It will catch all issues early, including Prettier formatting errors.
+   - Husky pre-commit hooks are set up to run these checks automatically before every commit. If any issues are found, the commit will be blocked until resolved.
+   - No need to manually order validation steps—Husky enforces this for you.
 
 2. **Optionally, run `pnpm format:check` for a quick formatting check before staging changes.**
 
-3. **Husky pre-commit hooks** are set up to run these checks automatically before every commit.
-   - If any issues are found, the commit will be blocked until resolved.
-   - No need to manually order validation steps.
-
 **Summary:**
-Always run `pnpm pre-commit` before `git add` or `git commit` to catch all formatting, lint, type, and test errors. Husky hooks automate this process for you.
+Always run `pnpm pre-commit` before `git add` or `git commit` to catch all formatting, lint, type, and test errors. Husky hooks automate this process and block commits with formatting errors.
+
+**Formatting enforcement:**
+- Formatting is enforced locally via Husky pre-commit hooks and in CI via the `pnpm format:check` job.
+- Contributors should run `pnpm pre-commit` and/or `pnpm format:check` before staging or committing changes.
+- PRs and merges will be blocked if formatting is incorrect.
 
 ### Security
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+# Contributor Checklist
+- [ ] I ran `pnpm pre-commit` and/or `pnpm format:check` before submitting this PR to ensure all formatting, lint, type, and test checks pass.
 # Pull Request
 
 ## 📋 Description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 # Contributor Checklist
+- [ ] I used ES module syntax (`import`/`export`) and did not use `require()` imports in any TypeScript code.
+# Contributor Checklist
+
 - [ ] I ran `pnpm pre-commit` and/or `pnpm format:check` before submitting this PR to ensure all formatting, lint, type, and test checks pass.
+
 # Pull Request
 
 ## 📋 Description

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,7 @@ const eslintConfig = [
           message: "Do not log secrets, API keys, or sensitive config.",
         },
       ],
+      "@typescript-eslint/no-require-imports": "error",
     },
   },
 ];

--- a/src/test/alias-enforcement.test.ts
+++ b/src/test/alias-enforcement.test.ts
@@ -52,4 +52,21 @@ describe("Path Alias Enforcement", () => {
       });
     });
   });
+  describe("Path alias enforcement in index.ts files", () => {
+    const filesToCheck = [
+      "src/types/components/index.ts",
+      "src/types/components/ui/index.ts",
+      "src/types/mailchimp/index.ts",
+    ];
+
+    filesToCheck.forEach((file) => {
+      it(`should not use relative path exports in ${file}`, () => {
+        const content = fs.readFileSync(file, "utf8");
+        const matches = content.match(
+          /export\s+\*\s+from\s+['\"](\.[^'\"]+)['\"]/g,
+        );
+        expect(matches).toBeNull();
+      });
+    });
+  });
 });

--- a/src/types/components/index.ts
+++ b/src/types/components/index.ts
@@ -1,1 +1,1 @@
-export * from "./ui";
+export * from "@/types/components/ui";

--- a/src/types/components/ui/index.ts
+++ b/src/types/components/ui/index.ts
@@ -1,1 +1,1 @@
-export * from "./pagination";
+export * from "@/types/components/ui/pagination";

--- a/src/types/mailchimp/index.ts
+++ b/src/types/mailchimp/index.ts
@@ -1,2 +1,2 @@
-export * from "./common";
-export * from "./dashboard-pagination";
+export * from "@/types/mailchimp/common";
+export * from "@/types/mailchimp/dashboard-pagination";


### PR DESCRIPTION
- Add ESLint rule to block require() imports in TypeScript
- Update documentation and PR template for contributor guidance
- Relates to #70

This PR enforces ES module syntax across the codebase, blocks require() imports in TypeScript via ESLint, and updates contributor documentation and PR templates to guide best practices. All changes have passed pre-commit and CI validation.