### PR TITLE
fix: improve pre-commit workflow with lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,5 @@
 echo "🔍 Running pre-commit validation..."
-pnpm pre-commit
+echo "📝 Formatting and linting staged files..."
+pnpm lint-staged
+echo "🧪 Running full validation suite..."
+pnpm check:no-secrets-logged && pnpm type-check && pnpm test && pnpm test:a11y

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ### Development
+
 - `pnpm dev` - Start development server with HTTPS, Turbopack, and experimental features
-- `pnpm build` - Build production version with Turbopack  
+- `pnpm build` - Build production version with Turbopack
 - `pnpm start` - Start production server
 - `pnpm clean` - Remove build artifacts (.next, out, dist)
 
 ### Quality Assurance
+
 - `pnpm lint` - Run ESLint on src and scripts directories
 - `pnpm lint:fix` - Fix auto-fixable ESLint issues
 - `pnpm type-check` - Run TypeScript compiler without emitting files
@@ -18,6 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pnpm format:check` - Check code formatting without fixing
 
 ### Testing
+
 - `pnpm test` - Run all tests with Vitest
 - `pnpm test:watch` - Run tests in watch mode
 - `pnpm test:ui` - Run tests with Vitest UI interface
@@ -25,23 +28,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pnpm test:a11y` - Run accessibility-specific tests only
 
 ### Validation Workflows
+
 - `pnpm quick-check` - Fast validation (type-check + lint)
 - `pnpm pre-commit` - Full validation: format, secrets check, lint, type-check, test, a11y
 - `pnpm validate` - Complete validation including production build
 - `pnpm check:no-secrets-logged` - Scan for suspicious logging patterns that could leak secrets
 
 ### Documentation
+
 - `pnpm docs` - Generate TypeDoc documentation
 - `pnpm docs:watch` - Generate documentation in watch mode
 
 ## Architecture
 
 ### Project Status & Context
+
 - **Status**: MVP Complete with ongoing enhancements
 - **Current Phase**: Post-MVP feature development and workflow optimization
 - **Key Achievement**: 70x acceleration - 10-week roadmap completed in 1 day
 
 ### Core Framework & Libraries
+
 - **Next.js 15** with App Router architecture
 - **TypeScript** with strict configuration and comprehensive path aliases
 - **Tailwind CSS v4** for styling with shadcn/ui components
@@ -50,12 +57,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **ES Modules**: All scripts use ES module syntax (`import`/`export`), `require()` is forbidden
 
 ### Project Structure & Import Strategy
+
 - **Path aliases configured**: `@/*`, `@/components/*`, `@/actions/*`, `@/types/*`, `@/schemas/*`, `@/utils/*`, `@/lib/*`, `@/dal/*`
 - **Centralized exports**: All folders use index.ts files with path aliases (no relative imports)
 - **Type enforcement**: Shared types must be defined in `/src/types` (no inline definitions)
 - **Schema enforcement**: Zod schemas must be defined in `/src/schemas` (no inline definitions)
 
 ### Key Directories
+
 - `src/app/` - Next.js App Router pages, layouts, and API routes
 - `src/components/` - Reusable UI components organized by feature (ui/, dashboard/, layout/, accessibility/, performance/, pwa/, social/)
 - `src/actions/` - Server actions and business logic with comprehensive test coverage
@@ -70,12 +79,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `src/dal/` - Data Access Layer structure for future database integration
 
 ### Configuration Files
+
 - **tsconfig.json**: Strict TypeScript with comprehensive path aliases
 - **vitest.config.ts**: Test configuration with jsdom environment and coverage setup
 - **next.config.ts**: Minimal Next.js configuration
 - **scripts/check-no-secrets-logged.js**: Security script to prevent secret logging
 
 ### Core Features & Integrations
+
 - **Mailchimp Integration**: Full API integration with campaigns, audiences, and dashboard data
 - **Accessibility (A11y)**: axe-core integration with development-time checking and test utilities
 - **Performance Monitoring**: Web Vitals tracking with multiple analytics provider support
@@ -84,6 +95,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Error Handling**: React Error Boundaries and centralized error management
 
 ### Quality Standards
+
 - **Pre-commit hooks**: Automatic formatting, linting, type-checking, testing, and security scanning
 - **Accessibility testing**: Automated WCAG 2.1 AA compliance testing in development and CI
 - **Type safety**: Strict TypeScript configuration with no implicit any
@@ -91,12 +103,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Performance**: Core Web Vitals monitoring and bundle size optimization
 
 ### Environment & Configuration
+
 - **Environment validation**: Zod-based environment variable validation in `src/lib/config.ts`
 - **Mock data support**: Configurable mock data for development and CI environments
 - **Security scanning**: Automated detection of logged secrets or API keys
 - **HTTPS development**: Local development server with HTTPS certificates
 
 ### Testing Strategy
+
 - **Unit tests**: Vitest with React Testing Library
 - **Accessibility tests**: axe-core integration for automated a11y testing
 - **Architectural enforcement tests**: Automated tests to enforce coding standards
@@ -108,12 +122,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development Guidelines
 
 ### Required Documentation Reading
+
 Before starting any development work, always review:
+
 1. **`docs/PRD.md`** - Product Requirements Document with problem statement, solution overview, and success criteria
 2. **`docs/project-management/development-roadmap.md`** - Development progress and current status
 3. **`docs/project-management/task-tracking.md`** - Current priorities and performance metrics
 
 ### Code Organization
+
 - **Path aliases**: Use consistently - avoid relative imports in index.ts files (enforced by automated tests)
 - **Type definitions**: Define shared types in `/src/types` with subfolder organization, never inline (enforced by automated tests)
 - **Schema definitions**: Create Zod schemas in `/src/schemas` for all validation, never inline (enforced by automated tests)
@@ -123,25 +140,32 @@ Before starting any development work, always review:
 - **Data Access Layer**: Follow DAL pattern for future database integration
 
 ### Schema & API Patterns
+
 - **Error response strategy**: Compare fields to shared error schema, extend with `.extend({ ... })` if needed, or create custom schema if fundamentally different
 - **API naming consistency**: Always use the same object/property names as the API when defining Zod schemas and TypeScript types
 - **Enum pattern**: Define as constant array (e.g., `export const VISIBILITY = ["pub", "prv"] as const;`) and use in `z.enum(VISIBILITY)`
 
 ### Component Development
+
 - **Server Components**: Use by default, only mark with 'use client' when needed
 - **Atomic design**: Follow atoms, molecules, organisms pattern
 - **shadcn/ui**: Use as base building blocks
 - **JSDoc**: Document component usage with comments
 
 ### Quality Assurance Workflow
-1. **Always run `pnpm pre-commit` before committing changes**
-   - Automatically runs: formatting, secret checking, linting, type-checking, testing, and accessibility testing
+
+1. **Automatic pre-commit validation** (enforced by Husky hooks):
+   - **lint-staged**: Automatically formats and lints only staged files
+   - **Full validation**: Secret checking, type-checking, testing, and accessibility testing
    - All checks must pass before commits are allowed
-   - Husky pre-commit hooks enforce this automatically
-2. **Use `pnpm quick-check` for faster iteration during development** (type-check + lint only)
-3. **Use `pnpm format:check` for quick formatting verification**
+   - Formatted changes are automatically included in the commit
+2. **Manual validation options**:
+   - `pnpm pre-commit` - Full validation suite (same as automatic pre-commit)
+   - `pnpm quick-check` - Fast validation (type-check + lint only)
+   - `pnpm format:check` - Check formatting without fixing
 
 ### Branch & Commit Strategy
+
 - **Branch naming**: Use `feature/description-of-feature` or `fix/description-of-fix` with lowercase and hyphens
 - **Conventional commits**: Follow `type(scope): description` format
   - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
@@ -150,12 +174,14 @@ Before starting any development work, always review:
 - **Code review**: Reviewers must confirm all index.ts files use path aliases for exports
 
 ### Performance Guidelines
+
 - **Core Web Vitals**: Track LCP, FID, CLS using WebVitalsReporter component
 - **Performance monitoring**: Use hooks like `useWebVitals`, `usePageLoadPerformance`
 - **Bundle optimization**: Monitor bundle size and implement performance budgets
 - **Next.js Image**: Use for all images with proper code splitting
 
 ### Accessibility Standards
+
 - **WCAG 2.1 AA compliance**: Minimum standard with automated testing
 - **Semantic HTML**: Use proper elements (header, nav, main, section)
 - **Keyboard navigation**: Ensure all interactive elements work via keyboard
@@ -164,6 +190,7 @@ Before starting any development work, always review:
 - **Development tools**: Use A11yProvider for real-time checking
 
 ### Security & Best Practices
+
 - Never log environment variables, API keys, or secrets (enforced by automated scanning)
 - Use the centralized environment validation in `src/lib/config.ts`
 - All API endpoints must use Zod schemas for input validation

--- a/package.json
+++ b/package.json
@@ -25,6 +25,15 @@
     "validate": "pnpm pre-commit && pnpm build",
     "quick-check": "pnpm type-check && pnpm lint"
   },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{json,md,css,html,yml,yaml}": [
+      "prettier --write"
+    ]
+  },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-navigation-menu": "^1.2.14",


### PR DESCRIPTION
## Summary
- Add lint-staged configuration to automatically format and stage files during pre-commit
- Update Husky pre-commit hook to use lint-staged for more efficient processing  
- Ensure formatted changes are automatically included in commits
- Update CLAUDE.md documentation to reflect the improved workflow

## Problem Solved
Previously, Prettier would run during the pre-commit process but any formatting changes would be left uncommitted, requiring a second commit. This fixes that by:

1. Using lint-staged to format only staged files
2. Automatically staging the formatted changes as part of the pre-commit process
3. Running full validation after formatting is complete

## Key Changes
- **lint-staged configuration** in package.json for JS/TS and other file types
- **Updated Husky pre-commit hook** to use lint-staged workflow
- **Improved documentation** in CLAUDE.md explaining the new process

## Test Results
✅ Pre-commit hook runs successfully  
✅ Formatting changes are automatically staged and included in commit  
✅ All validation passes (secrets, type-check, tests, a11y)  
✅ No uncommitted changes left after commit process

🤖 Generated with [Claude Code](https://claude.ai/code)