### PR TITLE
docs: add pnpm Homebrew management information to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Current Phase**: Post-MVP feature development and workflow optimization
 - **Key Achievement**: 70x acceleration - 10-week roadmap completed in 1 day
 
+### Environment Requirements
+
+- **Node.js**: v24.7.0 (Latest LTS)
+- **pnpm**: v10.15.0 (managed via Homebrew)
+  - **Installation**: `brew install pnpm`
+  - **Updates**: `brew upgrade pnpm` (prevents auto-update conflicts)
+  - **Location**: `/usr/local/bin/pnpm`
+  - **Note**: Using Homebrew prevents "Auto-update failed" messages
+
 ### Core Framework & Libraries
 
 - **Next.js 15** with App Router architecture


### PR DESCRIPTION
## Summary
- Add environment requirements section to CLAUDE.md
- Document that pnpm is managed via Homebrew (not auto-update)
- Include specific version info and installation commands

## Problem Solved
Previously, pnpm would show "Auto-update failed" messages because it was installed via Homebrew but trying to self-update. This documents the correct management approach.

## Key Information Added
- **Node.js version**: v24.7.0 (Latest LTS)
- **pnpm version**: v10.15.0 (Homebrew-managed)
- **Installation**: `brew install pnpm`
- **Updates**: `brew upgrade pnpm`
- **Location**: `/usr/local/bin/pnpm`

This ensures future Claude instances understand the environment setup and won't encounter update conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)