### PR TITLE
Fix Mailchimp audience response schema structure

### DIFF
--- a/src/schemas/mailchimp/audience-response.schema.ts
+++ b/src/schemas/mailchimp/audience-response.schema.ts
@@ -3,11 +3,36 @@ import { MailchimpAudienceSchema } from "@/schemas/mailchimp/audience.schema";
 
 /**
  * MailchimpAudienceResponseSchema
- * Zod schema for Mailchimp Audience API success response.
- * Source: https://mailchimp.com/developer/marketing/api/audiences/get-a-list-of-audiences/
+ * Zod schema for Mailchimp Lists API success response structure
+ *
+ * Issue #85: Fixed property names and added missing metadata fields
+ * Based on: https://mailchimp.com/developer/marketing/api/lists/
+ * Service usage: /src/services/mailchimp.service.ts getLists method
  */
 export const MailchimpAudienceResponseSchema = z.object({
-  audiences: z.array(MailchimpAudienceSchema),
+  // Core response data - API returns 'lists' not 'audiences'
+  lists: z.array(MailchimpAudienceSchema),
+
+  // Pagination metadata
   total_items: z.number(),
-  // Add other metadata fields from the API as needed
+
+  // Account constraints/quota information
+  constraints: z.object({
+    may_create: z.boolean(),
+    max_instances: z.number(),
+    current_total_instances: z.number(),
+  }),
+
+  // Navigation links (may not always be present)
+  _links: z
+    .array(
+      z.object({
+        rel: z.string(),
+        href: z.string().url(),
+        method: z.string(),
+        targetSchema: z.string().optional(),
+        schema: z.string().optional(),
+      }),
+    )
+    .optional(),
 });

--- a/src/test/audience-schema.test.ts
+++ b/src/test/audience-schema.test.ts
@@ -57,10 +57,50 @@ describe("MailchimpAudienceResponseSchema", () => {
   it("validates a correct response", () => {
     expect(() =>
       MailchimpAudienceResponseSchema.parse({
-        audiences: [validAudience],
+        lists: [validAudience],
         total_items: 1,
+        constraints: {
+          may_create: true,
+          max_instances: 100,
+          current_total_instances: 5,
+        },
       }),
     ).not.toThrow();
+  });
+
+  it("validates response with optional _links", () => {
+    expect(() =>
+      MailchimpAudienceResponseSchema.parse({
+        lists: [validAudience],
+        total_items: 1,
+        constraints: {
+          may_create: false,
+          max_instances: 50,
+          current_total_instances: 50,
+        },
+        _links: [
+          {
+            rel: "self",
+            href: "https://us1.api.mailchimp.com/3.0/lists",
+            method: "GET",
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("fails validation with old 'audiences' property", () => {
+    expect(() =>
+      MailchimpAudienceResponseSchema.parse({
+        audiences: [validAudience], // Wrong property name
+        total_items: 1,
+        constraints: {
+          may_create: true,
+          max_instances: 100,
+          current_total_instances: 5,
+        },
+      }),
+    ).toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

Corrects the Mailchimp audience response schema to match the actual API response structure, fixing property names and adding missing metadata fields.

## Changes Made

### Schema Updates (`src/schemas/mailchimp/audience-response.schema.ts`)
- **Fixed property name**: Changed `audiences` to `lists` to match actual API response
- **Added `constraints` object**: Account quota and limitation information
- **Added optional `_links` array**: API navigation links for HATEOAS support
- **Enhanced documentation**: Clear field descriptions and issue references

### Test Updates (`src/test/audience-schema.test.ts`)
- **Updated test data**: Using correct `lists` property name
- **Added realistic constraints**: Testing with proper quota information
- **Added `_links` test**: Testing optional navigation links
- **Backward compatibility test**: Ensures old `audiences` property fails validation

## Issues Fixed

**Property Name Mismatch:**
```typescript
// Before (INCORRECT)
{
  audiences: [...], // Wrong property name
  total_items: 123
}

// After (CORRECT)  
{
  lists: [...], // Matches actual API response
  total_items: 123,
  constraints: { ... }, // Required quota info
  _links: [...] // Optional navigation
}
```

## Evidence of Correct Structure

- **Service layer expects `lists`**: `/src/services/mailchimp.service.ts` line 393
- **Page component uses `lists`**: `/src/app/mailchimp/audiences/page.tsx` line 90-91
- **Types define `lists`**: `/src/types/mailchimp/audience.ts` line 48

## Testing

- ✅ All 256 tests pass (+2 new tests)
- ✅ TypeScript compilation successful  
- ✅ Pre-commit hooks pass
- ✅ Enhanced test coverage with realistic response data

## Impact

- **Correct API validation** - Schema now matches real responses
- **Better error detection** - Invalid responses will be caught
- **Complete response coverage** - Includes all response metadata
- **Improved documentation** - Clear field purposes and requirements

## Dependencies

- **Depends on #84** ✅ - Core schema foundation (merged)
- **Enables #87** - Realistic test data updates
- **Foundation for #88** - API route validation integration

Closes #85

🤖 Generated with [Claude Code](https://claude.ai/code)