### PR TITLE
Fix DAL relative imports and enhance alias enforcement test

### DIFF
--- a/src/dal/index.ts
+++ b/src/dal/index.ts
@@ -1,10 +1,10 @@
 // Export all DAL modules for easier imports
 
 // Models
-export * from "./models/audience.model";
+export * from "@/dal/models/audience.model";
 
 // Repositories
-export * from "./repositories/audience.repository";
+export * from "@/dal/repositories/audience.repository";
 
 // Services
-export * from "./services/audience.service";
+export * from "@/dal/services/audience.service";

--- a/src/test/alias-enforcement.test.ts
+++ b/src/test/alias-enforcement.test.ts
@@ -16,9 +16,12 @@ const ALIAS_FOLDERS = [
   "src/types",
   "src/utils",
   "src/components",
+  "src/dal",
 ];
 const RELATIVE_PATH_REGEX = /from ['"](\.\.\/)+/;
 const EXPORT_RELATIVE_PATH_REGEX = /export .*from ['"](\.\.\/)+/;
+const SAME_DIR_RELATIVE_REGEX = /from ['"]\.\//;
+const SAME_DIR_EXPORT_REGEX = /export .*from ['"]\.\//;
 
 function getAllFiles(dir: string, ext: string[] = [".ts", ".tsx"]): string[] {
   let results: string[] = [];
@@ -57,6 +60,7 @@ describe("Path Alias Enforcement", () => {
       "src/types/components/index.ts",
       "src/types/components/ui/index.ts",
       "src/types/mailchimp/index.ts",
+      "src/dal/index.ts",
     ];
 
     filesToCheck.forEach((file) => {
@@ -66,6 +70,34 @@ describe("Path Alias Enforcement", () => {
           /export\s+\*\s+from\s+['\"](\.[^'\"]+)['\"]/g,
         );
         expect(matches).toBeNull();
+      });
+    });
+  });
+
+  describe("DAL folder specific enforcement", () => {
+    it("should not use same-directory relative imports in src/dal", () => {
+      const files = getAllFiles(path.resolve("src/dal"));
+      files.forEach((file) => {
+        const content = fs.readFileSync(file, "utf8");
+        const matches = content.match(SAME_DIR_RELATIVE_REGEX);
+        if (matches) {
+          throw new Error(
+            `Found same-directory relative import in ${file}: ${matches[0]}`,
+          );
+        }
+      });
+    });
+
+    it("should not use same-directory relative exports in src/dal", () => {
+      const files = getAllFiles(path.resolve("src/dal"));
+      files.forEach((file) => {
+        const content = fs.readFileSync(file, "utf8");
+        const matches = content.match(SAME_DIR_EXPORT_REGEX);
+        if (matches) {
+          throw new Error(
+            `Found same-directory relative export in ${file}: ${matches[0]}`,
+          );
+        }
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR resolves the architectural violation where `src/dal/index.ts` was using relative imports instead of path aliases, and enhances the enforcement test to prevent future violations.

## Problem

Issue #100 was previously marked as closed, but the actual work was never implemented:
- `src/dal/index.ts` contained relative import violations: `export * from "./models/audience.model"`
- The existing `alias-enforcement.test.ts` didn't catch these violations because:
  - The `src/dal` folder was not included in the enforcement scope
  - Same-directory imports (`./`) weren't detected, only parent directory imports (`../`)

## Solution

### 1. Fixed the Import Violations ✅

Updated `src/dal/index.ts` to use path aliases consistently:

```typescript
// Before - using relative imports
export * from "./models/audience.model";
export * from "./repositories/audience.repository";
export * from "./services/audience.service";

// After - using path aliases
export * from "@/dal/models/audience.model";
export * from "@/dal/repositories/audience.repository";
export * from "@/dal/services/audience.service";
```

### 2. Enhanced Enforcement Test ✅

Enhanced `src/test/alias-enforcement.test.ts` with:
- **Added DAL monitoring**: Included `src/dal` in the list of folders checked for alias compliance
- **Same-directory detection**: Added regex patterns to catch `./` relative imports/exports
- **DAL-specific tests**: Created dedicated enforcement tests for the DAL layer
- **Comprehensive coverage**: Added `src/dal/index.ts` to the specific files being monitored

## Verification

- ✅ Enhanced test correctly detects violations (tested before fix)
- ✅ All tests pass after applying path aliases (294/294 tests)
- ✅ TypeScript compilation succeeds without errors
- ✅ Full pre-commit validation passes (format, lint, type-check, test, a11y)
- ✅ No regressions introduced

## Test Results

The new enforcement tests specifically catch:
- Same-directory relative imports (`from "./..."`)
- Same-directory relative exports (`export * from "./..."`)
- Both in general DAL scanning and specific index.ts monitoring

This ensures architectural consistency and prevents future violations while maintaining all existing functionality.

Fixes #100

## Test plan

- [x] Verify relative imports are replaced with path aliases
- [x] Confirm enhanced test catches violations when introduced
- [x] Ensure all existing tests continue to pass
- [x] Validate TypeScript compilation succeeds
- [x] Check pre-commit hooks pass completely

🤖 Generated with [Claude Code](https://claude.ai/code)