### PR TITLE
fix: clean up audience schema by removing unused code and moving types

### DIFF
--- a/src/app/mailchimp/audiences/page.test.tsx
+++ b/src/app/mailchimp/audiences/page.test.tsx
@@ -39,7 +39,7 @@ vi.mock("@/components/dashboard/shared/dashboard-error", () => ({
 import { AudienceStats } from "@/components/mailchimp/audiences/AudienceStats";
 import { ClientAudienceList } from "@/components/mailchimp/audiences/ClientAudienceList";
 import type { MailchimpList } from "@/services";
-import type { AudienceStats as AudienceStatsType } from "@/schemas/mailchimp/audience.schema";
+import type { AudienceStats as AudienceStatsType } from "@/types/mailchimp/audience";
 
 const mockAudiences: MailchimpList[] = [
   {

--- a/src/app/mailchimp/audiences/page.tsx
+++ b/src/app/mailchimp/audiences/page.tsx
@@ -13,7 +13,7 @@ import {
 import { ClientAudienceList } from "@/components/mailchimp/audiences/ClientAudienceList";
 import { AudienceStats } from "@/components/mailchimp/audiences/AudienceStats";
 import { getMailchimpService, type MailchimpList } from "@/services";
-import type { AudienceStats as AudienceStatsType } from "@/schemas/mailchimp/audience.schema";
+import type { AudienceStats as AudienceStatsType } from "@/types/mailchimp/audience";
 
 interface AudiencesPageProps {
   searchParams: Promise<{

--- a/src/components/mailchimp/audiences/AudienceStats.test.tsx
+++ b/src/components/mailchimp/audiences/AudienceStats.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@/test/test-utils";
 import { expectNoA11yViolations, renderWithA11y } from "@/test/axe-helper";
 import { AudienceStats } from "./AudienceStats";
-import type { AudienceStats as AudienceStatsType } from "@/schemas/mailchimp/audience.schema";
+import type { AudienceStats as AudienceStatsType } from "@/types/mailchimp/audience";
 
 const mockStats: AudienceStatsType = {
   total_audiences: 3,

--- a/src/schemas/mailchimp/audience.schema.ts
+++ b/src/schemas/mailchimp/audience.schema.ts
@@ -8,68 +8,6 @@
 import { z } from "zod";
 
 /**
- * Visibility enum for Mailchimp audiences
- */
-export const VISIBILITY = ["pub", "prv"] as const;
-
-/**
- * Sync status enum for database operations
- */
-export const SYNC_STATUS = [
-  "pending",
-  "syncing",
-  "completed",
-  "failed",
-] as const;
-
-/**
- * Sort fields enum for query filters
- */
-export const SORT_FIELDS = [
-  "created_at",
-  "updated_at",
-  "name",
-  "member_count",
-  "engagement_rate",
-] as const;
-
-/**
- * Sort order enum
- */
-export const SORT_ORDER = ["asc", "desc"] as const;
-
-/**
- * Schema for audience query filters in the database
- */
-export const AudienceQueryFiltersSchema = z.object({
-  // Basic filters
-  ids: z.array(z.string()).optional(),
-  name_contains: z.string().optional(),
-  visibility: z.enum(VISIBILITY).optional(),
-
-  // Status filters
-  sync_status: z.enum(SYNC_STATUS).optional(),
-  is_deleted: z.boolean().optional(),
-
-  // Date filters
-  created_after: z.string().optional(),
-  created_before: z.string().optional(),
-  last_synced_after: z.string().optional(),
-  last_synced_before: z.string().optional(),
-
-  // Performance filters
-  min_member_count: z.number().int().min(0).optional(),
-  max_member_count: z.number().int().min(0).optional(),
-  min_engagement_rate: z.number().min(0).max(1).optional(),
-
-  // Pagination
-  offset: z.number().int().min(0).default(0),
-  limit: z.number().int().min(1).max(100).default(20),
-  sort_by: z.enum(SORT_FIELDS).default("created_at"),
-  sort_order: z.enum(SORT_ORDER).default("desc"),
-});
-
-/**
  * Schema for audience aggregate statistics
  * Simplified to match data actually available from Mailchimp API
  */
@@ -81,24 +19,3 @@ export const AudienceStatsSchema = z.object({
     prv: z.number().int().min(0),
   }),
 });
-
-/**
- * TypeScript type exports
- */
-export type AudienceStats = z.infer<typeof AudienceStatsSchema>;
-
-/**
- * Validation helper functions
- */
-export const AudienceModelValidators = {
-  /**
-   * Validates query filters
-   */
-  validateFilters: (data: unknown) => {
-    const result = AudienceQueryFiltersSchema.safeParse(data);
-    if (!result.success) {
-      throw new Error(`Invalid query filters: ${result.error.message}`);
-    }
-    return result.data;
-  },
-};

--- a/src/types/mailchimp/audience.ts
+++ b/src/types/mailchimp/audience.ts
@@ -1,13 +1,5 @@
 import type { z } from "zod";
-import type {
-  AudienceQueryFiltersSchema,
-  AudienceStatsSchema,
-} from "@/schemas/mailchimp/audience.schema";
-
-/**
- * TypeScript type for audience query filters
- */
-export type AudienceQueryFilters = z.infer<typeof AudienceQueryFiltersSchema>;
+import type { AudienceStatsSchema } from "@/schemas/mailchimp/audience.schema";
 
 /**
  * TypeScript type for audience statistics


### PR DESCRIPTION
## Summary
- Remove unused AudienceQueryFiltersSchema and related constants (VISIBILITY, SYNC_STATUS, SORT_FIELDS, SORT_ORDER)
- Remove unused AudienceModelValidators helper functions  
- Move AudienceStats type from schema to types folder following project conventions
- Update imports across codebase to reference types from correct location
- Retain only AudienceStatsSchema which is actively used for API responses

This cleanup removes legacy database-oriented filtering code that doesn't align with the current read-only Mailchimp API architecture.

## Test plan
- [x] Type checking passes
- [x] All tests pass (222/222)
- [x] Accessibility tests pass
- [x] Linting passes
- [x] Pre-commit validation passes

🤖 Generated with [Claude Code](https://claude.ai/code)