### PR TITLE
fix: refactor Mailchimp service types and parameter handling

### DIFF
--- a/src/lib/mailchimp.ts
+++ b/src/lib/mailchimp.ts
@@ -8,27 +8,13 @@
 
 import mailchimp from "@mailchimp/mailchimp_marketing";
 import { env } from "@/lib/config";
+import type { ApiResponse } from "@/types/api-errors";
 
 // Configure the Mailchimp SDK once
 mailchimp.setConfig({
   apiKey: env.MAILCHIMP_API_KEY,
   server: env.MAILCHIMP_SERVER_PREFIX || "us1",
 });
-
-/**
- * Simple response wrapper for consistency
- */
-export interface ApiResponse<T> {
-  success: boolean;
-  data?: T;
-  error?: string;
-  statusCode?: number;
-  rateLimit?: {
-    remaining: number;
-    resetTime: Date;
-    limit?: number;
-  };
-}
 
 /**
  * Simple error formatter for SDK responses

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,7 +10,8 @@ export {
 } from "@/services/mailchimp.service";
 
 // Re-export simple Mailchimp SDK setup for backward compatibility
-export { mailchimp, mailchimpCall, type ApiResponse } from "@/lib/mailchimp";
+export { mailchimp, mailchimpCall } from "@/lib/mailchimp";
+export type { ApiResponse } from "@/types/api-errors";
 
 // Keep auth service export for compatibility
 export { AuthService, authService } from "@/services/auth.service";

--- a/src/services/mailchimp.service.ts
+++ b/src/services/mailchimp.service.ts
@@ -7,7 +7,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // SDK interop requires any types for proper functioning
 
-import { mailchimp, mailchimpCall, type ApiResponse } from "@/lib/mailchimp";
+import { mailchimp, mailchimpCall } from "@/lib/mailchimp";
+import type { ApiResponse } from "@/types/api-errors";
+import { transformCampaignReportsParams } from "@/utils/mailchimp/query-params";
+import { transformPaginationParams } from "@/utils/mailchimp/query-params";
 import type {
   CampaignReport,
   ReportListSuccess,
@@ -17,11 +20,14 @@ import type {
   AudiencesPageSearchParams,
   CampaignsPageSearchParams,
   MailchimpRoot,
+  MailchimpRootQuery,
+  MailchimpAudienceSuccess,
 } from "@/types/mailchimp";
 import {
   MailchimpAudienceQuerySchema,
   ReportListQueryInternalSchema,
   OpenListQueryParamsSchema,
+  MailchimpRootQuerySchema,
 } from "@/schemas/mailchimp";
 
 // Re-export the campaign report type for external use
@@ -35,19 +41,11 @@ export class MailchimpService {
    */
   async getAudiences(
     params: AudiencesPageSearchParams,
-  ): Promise<ApiResponse<unknown>> {
-    // Transform page params to Mailchimp API format
-    const transformedParams = {
-      count: params.limit ? parseInt(params.limit, 10) : 10,
-      offset: params.page
-        ? (parseInt(params.page, 10) - 1) *
-          (params.limit ? parseInt(params.limit, 10) : 10)
-        : 0,
-      // Note: Other params like search, visibility, sync_status are not supported by the API
-      // They would need to be handled through client-side filtering
-    };
+  ): Promise<ApiResponse<MailchimpAudienceSuccess>> {
+    // Transform page params to Mailchimp API format, let schema handle defaults
+    const transformedParams = transformPaginationParams(params.page, params.limit);
 
-    // Validate transformed parameters using schema
+    // Validate transformed parameters using schema (applies defaults)
     const validationResult =
       MailchimpAudienceQuerySchema.safeParse(transformedParams);
     if (!validationResult.success) {
@@ -83,25 +81,10 @@ export class MailchimpService {
   async getCampaignReports(
     params: CampaignsPageSearchParams,
   ): Promise<ApiResponse<ReportListSuccess>> {
-    // Transform page params to Mailchimp API format
-    const transformedParams = {
-      count: params.perPage ? parseInt(params.perPage, 10) : 10,
-      offset: params.page
-        ? (parseInt(params.page, 10) - 1) *
-          (params.perPage ? parseInt(params.perPage, 10) : 10)
-        : 0,
-      type: params.type as
-        | "regular"
-        | "plaintext"
-        | "absplit"
-        | "rss"
-        | "variate"
-        | undefined,
-      before_send_time: params.before_send_time,
-      since_send_time: params.since_send_time,
-    };
+    // Transform page params to Mailchimp API format, let schema handle defaults
+    const transformedParams = transformCampaignReportsParams(params);
 
-    // Validate transformed parameters using schema
+    // Validate transformed parameters using schema (applies defaults)
     const validationResult =
       ReportListQueryInternalSchema.safeParse(transformedParams);
     if (!validationResult.success) {
@@ -153,8 +136,20 @@ export class MailchimpService {
   /**
    * System Operations
    */
-  async getApiRoot(params?: unknown): Promise<ApiResponse<MailchimpRoot>> {
-    return mailchimpCall(() => (mailchimp as any).root.getRoot(params));
+  async getApiRoot(params?: MailchimpRootQuery): Promise<ApiResponse<MailchimpRoot>> {
+    // Validate parameters if provided
+    if (params !== undefined) {
+      const validationResult = MailchimpRootQuerySchema.safeParse(params);
+      if (!validationResult.success) {
+        return {
+          success: false,
+          error: `Invalid API root query parameters: ${validationResult.error.message}`,
+        };
+      }
+      return mailchimpCall(() => (mailchimp as any).root.getRoot(validationResult.data));
+    }
+
+    return mailchimpCall(() => (mailchimp as any).root.getRoot());
   }
 
   async healthCheck(): Promise<ApiResponse<unknown>> {

--- a/src/types/api-errors.ts
+++ b/src/types/api-errors.ts
@@ -1,5 +1,20 @@
 // Custom error classes for API error handling
 
+/**
+ * Generic API response wrapper for consistency across all API calls
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  statusCode?: number;
+  rateLimit?: {
+    remaining: number;
+    resetTime: Date;
+    limit?: number;
+  };
+}
+
 export class BadRequestError extends Error {
   statusCode: number;
   constructor(message: string) {

--- a/src/utils/mailchimp/query-params.ts
+++ b/src/utils/mailchimp/query-params.ts
@@ -14,7 +14,7 @@ import { REPORT_TYPES } from "@/schemas/mailchimp/report-list-query.schema";
  * Used by service layer for converting URL params to API params
  *
  * @param page - Page number (1-based) as string
- * @param limit - Items per page as string  
+ * @param limit - Items per page as string
  * @returns Object with count and offset properties for Mailchimp API
  *
  * @example
@@ -138,13 +138,18 @@ export function validateCampaignsPageParams(
  * // Returns: { count: 25, offset: 25, type: "regular", before_send_time: "2024-01-01" }
  * ```
  */
-export function transformCampaignReportsParams(params: CampaignsPageSearchParams) {
+export function transformCampaignReportsParams(
+  params: CampaignsPageSearchParams,
+) {
   return {
     ...transformPaginationParams(params.page, params.perPage),
-    ...(params.type && REPORT_TYPES.includes(params.type as any) && {
-      type: params.type as typeof REPORT_TYPES[number]
+    ...(params.type &&
+      REPORT_TYPES.includes(params.type as (typeof REPORT_TYPES)[number]) && {
+        type: params.type as (typeof REPORT_TYPES)[number],
+      }),
+    ...(params.before_send_time && {
+      before_send_time: params.before_send_time,
     }),
-    ...(params.before_send_time && { before_send_time: params.before_send_time }),
     ...(params.since_send_time && { since_send_time: params.since_send_time }),
   };
 }

--- a/src/utils/mailchimp/query-params.ts
+++ b/src/utils/mailchimp/query-params.ts
@@ -8,6 +8,36 @@
 import { z } from "zod";
 import { MailchimpAudienceQuerySchema } from "@/schemas/mailchimp/audience-query.schema";
 import { CampaignsPageQuerySchema } from "@/schemas/mailchimp/campaign-query.schema";
+import { REPORT_TYPES } from "@/schemas/mailchimp/report-list-query.schema";
+/**
+ * Transforms page-based pagination parameters to Mailchimp API offset-based format
+ * Used by service layer for converting URL params to API params
+ *
+ * @param page - Page number (1-based) as string
+ * @param limit - Items per page as string  
+ * @returns Object with count and offset properties for Mailchimp API
+ *
+ * @example
+ * ```ts
+ * const params = transformPaginationParams("2", "25");
+ * // Returns: { count: 25, offset: 25 }
+ * ```
+ */
+function transformPaginationParams(
+  page?: string,
+  limit?: string,
+): { count?: number; offset?: number } {
+  const parsedLimit = limit ? parseInt(limit, 10) : undefined;
+  const parsedPage = page ? parseInt(page, 10) : undefined;
+
+  return {
+    ...(parsedLimit && { count: parsedLimit }),
+    ...(parsedPage && {
+      offset: (parsedPage - 1) * (parsedLimit || 10), // Use 10 as fallback for offset calculation
+    }),
+  };
+}
+import type { CampaignsPageSearchParams } from "@/types/mailchimp";
 
 /**
  * Date validation helper for YYYY-MM-DD format
@@ -93,3 +123,34 @@ export function validateCampaignsPageParams(
     data: result.data,
   };
 }
+
+/**
+ * Transform campaign reports page parameters to Mailchimp API format
+ * Combines pagination transformation with campaign-specific filters
+ *
+ * @param params - Campaign reports page search parameters
+ * @returns Object with API-ready parameters
+ *
+ * @example
+ * ```typescript
+ * const params = { page: "2", perPage: "25", type: "regular", before_send_time: "2024-01-01" };
+ * const result = transformCampaignReportsParams(params);
+ * // Returns: { count: 25, offset: 25, type: "regular", before_send_time: "2024-01-01" }
+ * ```
+ */
+export function transformCampaignReportsParams(params: CampaignsPageSearchParams) {
+  return {
+    ...transformPaginationParams(params.page, params.perPage),
+    ...(params.type && REPORT_TYPES.includes(params.type as any) && {
+      type: params.type as typeof REPORT_TYPES[number]
+    }),
+    ...(params.before_send_time && { before_send_time: params.before_send_time }),
+    ...(params.since_send_time && { since_send_time: params.since_send_time }),
+  };
+}
+
+/**
+ * Export the server-compatible transformPaginationParams function
+ * for use in service layer and other server-side code
+ */
+export { transformPaginationParams };

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -128,6 +128,9 @@ export function useStaticPaginationHandlers() {
   };
 }
 
+// Note: transformPaginationParams has been moved to @/utils/mailchimp/query-params
+// to be server-compatible (this file is client-side only due to useRouter usage)
+
 /**
  * Type definitions for pagination handlers
  */


### PR DESCRIPTION
## Summary
- Move ApiResponse type from `lib/mailchimp.ts` to `types/api-errors.ts` for centralized type management
- Add `transformPaginationParams` and `transformCampaignReportsParams` utilities for consistent API parameter transformation
- Improve type safety in MailchimpService methods with proper schema validation

## Test plan
- [x] All existing tests pass
- [x] TypeScript type checking passes
- [x] ESLint validation passes
- [x] Pre-commit validation suite passes

🤖 Generated with [Claude Code](https://claude.ai/code)